### PR TITLE
Include C stubs

### DIFF
--- a/dune
+++ b/dune
@@ -1,3 +1,6 @@
 (library
  (name PRNG)
- (public_name pringo))
+ (public_name pringo)
+ (foreign_stubs
+   (language c)
+   (names stubs)))


### PR DESCRIPTION
The previous port was missing the C stubs which would lead to errors like this when compiling:

```
/usr/bin/ld: duniverse/pringo/PRNG.a(pRNG.o): in function `camlPRNG__1':
:(.data+0x10c0): undefined reference to `pringo_LXM_make'
/usr/bin/ld: :(.data+0x10c8): undefined reference to `pringo_LXM_seed'
/usr/bin/ld: :(.data+0x10d0): undefined reference to `pringo_LXM_init_unboxed'
/usr/bin/ld: :(.data+0x10d8): undefined reference to `pringo_LXM_assign'
/usr/bin/ld: :(.data+0x10e0): undefined reference to `pringo_LXM_copy'
/usr/bin/ld: :(.data+0x10e8): undefined reference to `pringo_LXM_next_unboxed'
/usr/bin/ld: :(.data+0x10f0): undefined reference to `pringo_chacha_transform'
/usr/bin/ld: :(.data+0x10f8): undefined reference to `pringo_chacha_make_state'
/usr/bin/ld: :(.data+0x1100): undefined reference to `pringo_chacha_make_key'
/usr/bin/ld: :(.data+0x1108): undefined reference to `pringo_mixGamma_unboxed'
/usr/bin/ld: :(.data+0x1110): undefined reference to `pringo_mix30_unboxed'
/usr/bin/ld: :(.data+0x1118): undefined reference to `pringo_mix32_unboxed'
/usr/bin/ld: :(.data+0x1120): undefined reference to `pringo_mix64_unboxed'
collect2: error: ld returned 1 exit status
```

Fortunately the fix is quite simple - add the C stubs. These are nice and compact and build without jumping through hoops.